### PR TITLE
Pin dashboard tabs

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -7,3 +7,5 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "@popperjs/core", to: "popper.js", preload: true
+
+pin "dashboard_tabs", to: "dashboard/dashboard_tabs.js"


### PR DESCRIPTION
Fixed an issue where a js import was not pinned, leading to heroku not accessing the js file correctly