### PR TITLE
added resources to route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,17 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "pages#home"
+  resources :listings
+  resources :offers
+  resources :dashboard
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-  get "listings/:id", to: "listings#show", as: :listing
-  # Defines the root path route ("/")
-  # root "posts#index"
-  get "/dashboard", to: "dashboard#index", as: :dashboard
+#   get "up" => "rails/health#show", as: :rails_health_check
+#   # Defines the root path route ("/")
+#   # root "posts#index"
+
+#   get "/dashboard", to: "dashboard#index", as: :dashboard
 end


### PR DESCRIPTION
I added resources for listings, offers, and user controllers.
I checked the routes that resources created, it says that the prefix of the dashboard index is "dashboard_index"
so, I comment out the code below.

#   get "/dashboard", to: "dashboard#index", as: :dashboard

There might be some error because this dashboard path changed..sorry.