### PR TITLE
Dashboard views fixes for paths

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -4,6 +4,11 @@ class OffersController < ApplicationController
     @offers = @listing.offers
   end
 
+  def index
+    @listing = Listing.find(params["id"])
+    @offers = @listing.offers
+  end
+
   def create
     @listing = Listing.find(params[:listing_id])
     @offer = @listing.offers.new(offer_params)

--- a/app/views/dashboard/_dashboard_listings.html.erb
+++ b/app/views/dashboard/_dashboard_listings.html.erb
@@ -8,7 +8,7 @@
   <div class="dashboard-listings-container row d-flex justify-content-center w-100">
     <% @listings.each do |listing| %>
     <%# dashboard_listing_offers_path(listing) %>
-      <%= link_to dashboard_listing_offers_path(listing), class: "dashboard-listing card text-decoration-none col-2 m-2 p-1" do %>
+      <%= link_to offers_path(listing), class: "dashboard-listing card text-decoration-none col-2 m-2 p-1" do %>
         <img src="<%= listing.game.cover.url %>" alt="<%= listing.game.name %> cover art">
         <h4><%= listing.game.name %></h4>
         <p><strong>Offers: </strong><%= listing.offers.count %></p>

--- a/app/views/offers/index.html.erb
+++ b/app/views/offers/index.html.erb
@@ -6,7 +6,7 @@
         <% @offers.each do |offer| %>
           <div class="card-product mt-3">
             <p>Start Date: <%= offer.start_date %></p>
-            <p>End Date: <%= offer.start_date+offer.period %></p>
+            <p>End Date: <%= offer.start_date + @listing.max %></p>
             <p>Offer: <%= offer.price %></p>
             <p>Comments: <%= offer.comments %><p>
             <p>From <%= offer.user.email %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   resources :offers, only: [:update, :destroy]
-  get "dashboard/listings/:id/offers", to: "offers#for_listing", as: :dashboard_listing_offers
+  get "dashboard/listings/:id/offers", to: "offers#index", as: :offers
   get "/dashboard", to: "dashboard#index", as: :dashboard
 
   resources :listings, only: [:show] do


### PR DESCRIPTION
Corrected paths for clicking on cards in dashboard listings and offers. Listings click now sees the offers received for the listing, and clicking on games you have offered for takes you to a listing itself